### PR TITLE
add scsi-target-utils

### DIFF
--- a/mkosi.files/mkosi.fedora
+++ b/mkosi.files/mkosi.fedora
@@ -52,6 +52,7 @@ BuildPackages=
     smartmontools
     systemd
     systemd-pam
+    scsi-target-utils
     usbutils
     util-linux
     wget


### PR DESCRIPTION
Seems it sometimes tries to use the tgtd binary which is in this package in fedora