### PR TITLE
add nvme-cli for cleanup

### DIFF
--- a/mkosi.files/mkosi.fedora
+++ b/mkosi.files/mkosi.fedora
@@ -37,6 +37,7 @@ BuildPackages=
     lshw
     mdadm
     ncurses-base
+    nvme-cli
     openssl
     openssl-libs
     pam


### PR DESCRIPTION
Seems this is only used beginning in wallaby but sounds sensible nonetheless: https://docs.openstack.org/ironic/wallaby/admin/cleaning.html#how-do-i-change-the-priority-of-a-cleaning-step