### PR TITLE
match harder on string start

### DIFF
--- a/mkosi.extra/usr/lib/dracut/modules.d/01setup-ironic-python-agent/module-setup.sh
+++ b/mkosi.extra/usr/lib/dracut/modules.d/01setup-ironic-python-agent/module-setup.sh
@@ -31,13 +31,13 @@ function install() {
         ln_r "usr/${dir}" "$dir"
     done
     while read -r file; do
-        [[ "$file" =~ /boot/* ]] && continue
-        [[ "$file" =~ /dev/* ]] && continue
-        [[ "$file" =~ /run/* ]] && continue
-        [[ "$file" =~ /usr/lib/.build-id/* ]] && continue
-        [[ "$file" =~ /usr/share/info/* ]] && continue
-        [[ "$file" =~ /usr/share/licenses/* ]] && continue
-        [[ "$file" =~ /usr/share/man/* ]] && continue
+        [[ "$file" =~ ^/boot/* ]] && continue
+        [[ "$file" =~ ^/dev/* ]] && continue
+        [[ "$file" =~ ^/run/* ]] && continue
+        [[ "$file" =~ ^/usr/lib/.build-id/* ]] && continue
+        [[ "$file" =~ ^/usr/share/info/* ]] && continue
+        [[ "$file" =~ ^/usr/share/licenses/* ]] && continue
+        [[ "$file" =~ ^/usr/share/man/* ]] && continue
         [[ "$file" =~ */vmlinuz ]] && continue # ignore explicitly the kernel
         [[ "$file" =~ *.hmac ]] && continue
         if test -e "$file"; then


### PR DESCRIPTION
`/run/` matches `/usr/lib64/python3.9/asyncio/runners.py`, which is bad.
`^/run/` doesn't match it.