### PR TITLE
explicitly add packages

### DIFF
--- a/mkosi.extra/usr/lib/dracut/modules.d/01setup-ironic-python-agent/module-setup.sh
+++ b/mkosi.extra/usr/lib/dracut/modules.d/01setup-ironic-python-agent/module-setup.sh
@@ -14,7 +14,7 @@ function install() {
     declare -a _packages_to_install=("filesystem" "coreutils" "coreutils-common" "glibc" "glibc-common" "setup" "util-linux")
     _packages_to_install+=("fedora-release" "fedora-release-common")
     _packages_to_install+=("kernel-core" "kernel-modules" "kmod" "linux-firmware")
-    _packages_to_install+=("gdisk" "iscsi-initiator-utils" "mdadm" "parted" "qemu-img")
+    _packages_to_install+=("gdisk" "iscsi-initiator-utils" "mdadm" "parted" "qemu-img" "nvme-cli")
     _packages_to_install+=("biosdevname" "systemd" "systemd-libs" "systemd-networkd" "systemd-udev")
     _packages_to_install+=("dbus-broker" "dbus-common" "dbus-libs" "dbus-tools")
     _packages_to_install+=("ncurses" "ncurses-libs" "ncurses-base")

--- a/mkosi.files/mkosi.fedora
+++ b/mkosi.files/mkosi.fedora
@@ -14,31 +14,47 @@ WithNetwork=true
 BuildPackages=
     bash-completion
     bind-utils
+    bind-libs
+    bind-libs-lite
     binutils
     biosdevname
+    ca-certificates
     curl
+    dbus-broker
+    dbus-common
     dbus-libs
     dbus-tools
     dmidecode
     dracut
     efibootmgr
+    fedora-release
+    fedora-release-common
+    filesystem
+    gawk
     gcc
     gcc-c++
     gdisk
+    glibc
+    glibc-common
+    grep
     git
     hdparm
     ipmitool
     iproute
+    iputils
     iscsi-initiator-utils
     kernel
     kernel-core
     kernel-modules
     kmod
     less
+    libpwquality
     linux-firmware
     lshw
     mdadm
+    ncurses
     ncurses-base
+    ncurses-libs
     nvme-cli
     openssl
     openssl-libs
@@ -47,15 +63,20 @@ BuildPackages=
     pciutils
     pciutils-libs
     python3
+    python3-libs
     python3-devel
     python3-pip
     python3-rpm
     python3-systemd
     qemu-img
+    sed
+    setup
     smartmontools
     systemd
+    systemd-libs
     systemd-networkd
     systemd-pam
+    systemd-udev
     scsi-target-utils
     usbutils
     util-linux


### PR DESCRIPTION
Explicitly add all packages that are listed in mkosi.extra/usr/lib/dracut/modules.d/01setup-ironic-python-agent/module-setup.sh to make sure they are available