### PR TITLE
Add iso9660 for virtual-media-boot

### DIFF
--- a/mkosi.extra/etc/dracut.conf.d/99-ipa.conf
+++ b/mkosi.extra/etc/dracut.conf.d/99-ipa.conf
@@ -6,4 +6,5 @@ ro_mnt=yes
 hostonly=no
 hostonly_cmdline=no
 compress=zstd
-filesystems+=" btrfs ext4 squashfs fat vfat xfs "
+filesystems+=" btrfs ext4 squashfs fat vfat xfs iso9660"
+rd.driver.pre+=" iso9660"


### PR DESCRIPTION
Ironic will create an iso and place there some config files which are mounted in the initrd stage, so load it early. I am not clear on wether pre is acutally needed and post would suffice.