### PR TITLE
Fixup dracut conf (whitespaces and rd.driver.pre)

### DIFF
--- a/mkosi.extra/etc/dracut.conf.d/99-ipa.conf
+++ b/mkosi.extra/etc/dracut.conf.d/99-ipa.conf
@@ -6,5 +6,5 @@ ro_mnt=yes
 hostonly=no
 hostonly_cmdline=no
 compress=zstd
-filesystems+=" btrfs ext4 squashfs fat vfat xfs iso9660"
-rd.driver.pre+=" iso9660"
+filesystems+=" btrfs ext4 squashfs fat vfat xfs iso9660 "
+force_drivers+=" iso9660 "


### PR DESCRIPTION
dracut warns about these, as one cannot combine this setting with others due as += is string concatenation.

rd.driver.pre is the kernel argument, but force_drivers is the dracut config (presumably)