### PR TITLE
Use native systemd when supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ DISK_OPTS ?= -drive if=none,id=nvme0,cache=none,format=raw,aio=io_uring,file=vmd
 
 QEMU = $(SUDO) qemu-system-x86_64 -accel kvm -m 4096 -nographic $(BIOS_OPTS) $(DEVICE_OPTS) $(CPU_OPTS) $(NET_OPTS) $(DISK_OPTS)
 
-file_inputs = $(shell find src/ requirements/ mkosi.extra/)
+file_inputs = $(shell find src/ requirements/ mkosi.extra/ mkosi.conf.d/)
 mkosi_outputs = $(addprefix $(OUTPUT_DIR)/, $(OUTPUT) $(OUTPUT).vmlinuz $(OUTPUT).initrd)
-mkosi_inputs = mkosi.build.chroot mkosi.postinst.chroot mkosi.finalize mkosi.conf $(file_inputs)
+mkosi_inputs = mkosi.build.chroot mkosi.postinst.chroot mkosi.finalize $(file_inputs)
 
 .PHONY: default
 default: git-submodule-init build
@@ -42,7 +42,7 @@ iso: $(OUTPUT_DIR)/image.iso
 .PHONY: clean
 clean:
 	$(SUDO) rm -rf mkosi.builddir/image* mkosi.builddir/initrd*
-	$(MKOSI) --skip-final-phase false clean
+	$(MKOSI) clean
 
 build: $(OUTPUT_DIR)/$(OUTPUT).squashfs
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -1,1 +1,0 @@
-mkosi.files/mkosi.fedora

--- a/mkosi.conf.d/default.conf
+++ b/mkosi.conf.d/default.conf
@@ -3,10 +3,6 @@
 Distribution=fedora
 Release=38
 
-[Host]
-# QemuHeadless=yes
-ToolsTree=default
-
 [Output]
 Output=image
 Format=directory

--- a/mkosi.conf.d/host_tools_tree.conf
+++ b/mkosi.conf.d/host_tools_tree.conf
@@ -1,0 +1,5 @@
+[Match]
+SystemdVersion=<254
+
+[Host]
+ToolsTree=default


### PR DESCRIPTION
The newer version of mkosi support selecting the tools tree depending on the systemd version.
At the very least, that should speed things up in the CI, possibly fixing an error.